### PR TITLE
fix url not passing from provider instantiation to api

### DIFF
--- a/src/provider/index.test.ts
+++ b/src/provider/index.test.ts
@@ -1,0 +1,22 @@
+import { networks } from 'bitcoinjs-lib'
+import { Provider } from './index'
+import * as dotenv from 'dotenv'
+
+dotenv.config()
+
+describe('Provider', () => {
+  const urls = ['https://staging-api.oyl.gg/', 'https://api.oyl.gg/']
+
+  urls.forEach((url) => {
+    it(`should instantiate a new provider with the specified url: ${url}`, () => {
+      const provider = new Provider({
+        url,
+        projectId: process.env.SANDSHREW_PROJECT_ID!,
+        network: networks.bitcoin,
+        networkType: 'mainnet',
+      })
+      expect(provider).toBeDefined()
+      expect(provider.api.toObject().host).toBe(url)
+    })
+  })
+})

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -5,6 +5,14 @@ import { OylApiClient } from '../apiclient'
 import * as bitcoin from 'bitcoinjs-lib'
 import { waitForTransaction } from '../shared/utils'
 
+export type ProviderConstructorArgs = {
+  url: string
+  projectId: string
+  network: bitcoin.networks.Network
+  networkType: 'signet' | 'mainnet' | 'testnet'
+  version?: string
+}
+
 export class Provider {
   public sandshrew: SandshrewBitcoinClient
   public esplora: EsploraRpc
@@ -18,13 +26,7 @@ export class Provider {
     network,
     networkType,
     version = 'v1',
-  }: {
-    url: string
-    projectId: string
-    network: bitcoin.networks.Network
-    networkType: 'signet' | 'mainnet' | 'testnet'
-    version?: string
-  }) {
+  }: ProviderConstructorArgs) {
     let isTestnet: boolean
     let isRegtest: boolean
     switch (network) {
@@ -39,7 +41,7 @@ export class Provider {
     this.ord = new OrdRpc(masterUrl)
     this.api = new OylApiClient({
       network: networkType,
-      host: 'https://api.oyl.gg',
+      host: url,
       testnet: isTestnet ? true : null,
       regtest: isRegtest ? true : null,
       apiKey: projectId,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,5 +1,5 @@
 import { MnemonicToAccountOptions } from '../account'
-import { Provider } from '../provider/provider'
+import { Provider, ProviderConstructorArgs } from '../provider'
 import { Network, NetworkOptions } from './interface'
 import * as bitcoin from 'bitcoinjs-lib'
 import * as dotenv from 'dotenv'
@@ -11,12 +11,12 @@ export const maximumScriptBytes = 520
 
 export const MAXIMUM_FEE = 5000000
 
-export const regtestProvider = new Provider({
+export const regtestProviderConstructorArgs: ProviderConstructorArgs = {
   url: 'http://localhost:3000',
   projectId: 'regtest',
   network: bitcoin.networks.regtest,
   networkType: 'mainnet',
-})
+}
 
 export const regtestOpts: MnemonicToAccountOptions = {
   network: bitcoin.networks.regtest,

--- a/src/tests/cli.ts
+++ b/src/tests/cli.ts
@@ -40,7 +40,7 @@ import {
   mainnetMnemonic,
   regtestMnemonic,
   regtestOpts,
-  regtestProvider,
+  regtestProviderConstructorArgs,
 } from '../shared/constants'
 import * as collectible from '../collectible'
 import { commit, reveal, transfer, transferEstimate } from '../brc20'
@@ -495,6 +495,7 @@ export async function runCLI() {
   const networkConfig = config[network!]
 
   const { to, amount, feeRate, ticker, psbtBase64, price } = options
+  const regtestProvider = new Provider(regtestProviderConstructorArgs)
 
   const signer: Signer = new Signer(bitcoin.networks.regtest, {
     segwitPrivateKey: networkConfig.segwitPrivateKey,


### PR DESCRIPTION
This should fix an issue I was seeing where API calls were going to https://api.oyl.gg/ regardless of what is passed in to provider's instantiation.


I.e. I currently have:

```
  import { Provider } from '@oyl/sdk';
  const oyl = new Provider({
    // ...,
    url: 'https://staging-api.oyl.gg',
    // ...
  });
```

and get this error (notice the reference to api.oyl.gg, not staging-api.oyl.gg):

```
 ⨯ FetchError: invalid json response body at https://api.oyl.gg/get-rune-tickers reason: Unexpected token < in JSON at position 0
    at eval (webpack-internal:///(rsc)/./node_modules/node-fetch/lib/index.mjs:282:32)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async OylApiClient._call (webpack-internal:///(rsc)/./node_modules/@oyl/sdk/lib/apiclient/index.js:68:20)
    at async OylApiClient.getRuneTickers (webpack-internal:///(rsc)/./node_modules/@oyl/sdk/lib/apiclient/index.js:140:16)
    at async GET (webpack-internal:///(rsc)/./src/app/api/assets/route.ts:22:19)
    at async /Users/mcabrams/git/work/oyl.io/node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js:6:55038
    at async ek.execute (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js:6:45808)
    at async ek.handle (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js:6:56292)
    at async doRender (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:1377:42)
    at async cacheEntry.responseCache.get.routeKind (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:1599:28)
    at async DevServer.renderToResponseWithComponentsImpl (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:1507:28)
    at async DevServer.renderPageComponent (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:1931:24)
    at async DevServer.renderToResponseImpl (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:1969:32)
    at async DevServer.pipeImpl (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:920:25)
    at async NextNodeServer.handleCatchallRenderRequest (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/next-server.js:272:17)
    at async DevServer.handleRequestImpl (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/base-server.js:816:17)
    at async /Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/dev/next-dev-server.js:339:20
    at async Span.traceAsyncFn (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/trace/trace.js:154:20)
    at async DevServer.handleRequest (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
    at async invokeRender (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/lib/router-server.js:174:21)
    at async handleRequest (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/lib/router-server.js:353:24)
    at async requestHandlerImpl (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/lib/router-server.js:377:13)
    at async Server.requestListener (/Users/mcabrams/git/work/oyl.io/node_modules/next/dist/server/lib/start-server.js:141:13) {
  type: 'invalid-json'
```